### PR TITLE
Fixed the CPF/CNPJ data obtention from the forms

### DIFF
--- a/includes/class-wc-pagarme-api.php
+++ b/includes/class-wc-pagarme-api.php
@@ -284,12 +284,12 @@ class WC_Pagarme_API {
 		// Set the document number.
 		if ( class_exists( 'Extra_Checkout_Fields_For_Brazil' ) ) {
 			$wcbcf_settings = get_option( 'wcbcf_settings' );
-			if ( '0' !== $wcbcf_settings['person_type'] ) {
-				if ( ( '1' === $wcbcf_settings['person_type'] && '1' === $order->billing_persontype ) || '2' === $wcbcf_settings['person_type'] ) {
+			if ( 0 != $wcbcf_settings['person_type'] ) {
+				if ( ( 1 == $wcbcf_settings['person_type'] && 1 == $order->billing_persontype ) || 2 == $wcbcf_settings['person_type'] ) {
 					$data['customer']['document_number'] = $this->only_numbers( $order->billing_cpf );
 				}
 
-				if ( ( '1' === $wcbcf_settings['person_type'] && '2' === $order->billing_persontype ) || '3' === $wcbcf_settings['person_type'] ) {
+				if ( ( 1 == $wcbcf_settings['person_type'] && 2 == $order->billing_persontype ) || 3 == $wcbcf_settings['person_type'] ) {
 					$data['customer']['name']            = $order->billing_company;
 					$data['customer']['document_number'] = $this->only_numbers( $order->billing_cnpj );
 				}


### PR DESCRIPTION
The CPF/CNPJ was not being obtained correctly from the checkout forms; throwing
a message "Número do documento está faltando" when using credit card, and
using a random CPF number when using boleto.

Bug manifested itself when using the "Extra checkout fields for Brazil"
plugin.
Bug was introduced in commit fbb72009fcb1d73162367736b4fad17a0474ce5b.