### PR TITLE
Corrige o build dos testes e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,7 @@ wp-install:
 	&& docker-compose exec woopagarme chown www-data:www-data -R /var/www/html/wp-content/uploads/wc-logs
 
 wp-setup:
-	docker-compose exec woopagarme wp plugin install woocommerce \
+	docker-compose exec woopagarme wp plugin install woocommerce --version=3.7.0 \
 	woocommerce-extra-checkout-fields-for-brazil --activate --allow-root \
 	&& docker-compose exec woopagarme wp plugin activate woocommerce-pagarme --allow-root \
 	&& docker-compose exec woopagarme wp plugin install wordpress-importer --activate --allow-root \

--- a/tests/e2e/boleto.spec.js
+++ b/tests/e2e/boleto.spec.js
@@ -17,7 +17,8 @@ context('Boleto', () => {
 
     it('should countains boleto url', () => {
       cy.contains('Pagar boleto bancário')
-        .and('have.attr', 'href', 'https://pagar.me' )
+        .and('have.attr', 'href' )
+        .should('match', new RegExp(/https:\/\/api.pagar.me\/1\/boletos\/test_/g))
     })
   })
 })

--- a/tests/e2e/credit_card.spec.js
+++ b/tests/e2e/credit_card.spec.js
@@ -95,6 +95,9 @@ context('Credit card', () => {
                 metadata: { order_number: orderId }
               }
 
+              cy.log('Wait process transaction on Pagar.me')
+              cy.wait(5000)
+
               return cy.task('pagarmejs:transaction', opts)
                 .then(transaction => cy.task('pagarmejs:postback', transaction.id))
                 .then(postbacks => cy.updateOrderViaPostback(postbacks[0]))
@@ -109,7 +112,7 @@ context('Credit card', () => {
           cy.contains('Reembolso #')
           cy.contains('por pagarme')
 
-          cy.contains('-R$45.00')
+          cy.contains('-R$1.00')
         })
       })
     })
@@ -143,6 +146,9 @@ context('Credit card', () => {
               const opts = {
                 metadata: { order_number: orderId }
               }
+
+              cy.log('Wait process transaction on Pagar.me')
+              cy.wait(5000)
 
               return cy.task('pagarmejs:transaction', opts)
                 .then(transaction => cy.task('pagarmejs:postback', transaction.id))

--- a/tests/e2e/postback.spec.js
+++ b/tests/e2e/postback.spec.js
@@ -20,6 +20,9 @@ context('Postback last transaction', () => {
     })
 
     it('should contain at least one postback', () => {
+      cy.log('Wait process transaction on Pagar.me')
+      cy.wait(5000)
+      
       cy.task('pagarmejs:lastPostback')
         .then(postbacks => {
           expect(postbacks).to.not.be.empty


### PR DESCRIPTION
### Contexto
Investigando o motivo de falha dos testes e2e, o @murilohns descobriu que está relacionado com a versão do Woocommerce.

O último build que passou estava utilizando Woocommerce 3.7.0, e os builds seguintes começaram a usar Woocommerce 4.0 ou superior.

Aparentemente o Woocommerce 4.0+ não é compatível com PHP5.6, que é utilizado na imagem Docker para fazer o build, então ocorria uma falha na ativação do plugin.

### Correção
Para corrigir o build, vamos travar a versão do Woocommerce instalado em 3.7.0, que é a versão compatível com PHP5.6

No futuro podemos pensar em mudar a versão da imagem para PHP7, mas provavelmente terão algumas quebrar de interface com o módulo que precisarão ser corrigidas.

Também foi necessário corrigir alguns testes.

Obs.: PR feito em conjunto com o @murilohns. Relacionado a: https://github.com/claudiosanches/woocommerce-pagarme/pull/137 