### PR TITLE
Torna o plugin Brazilian Market on WooCommerce obrigatório

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 **Contributors:** pagarme, claudiosanches, murilohns  
 **Tags:** woocommerce, pagarme, payment  
 **Requires at least:** 4.0  
-**Tested up to:** 5.5  
-**Stable tag:** 2.3.0  
+**Tested up to:** 5.6  
+**Stable tag:** 2.4.0  
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -124,6 +124,10 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 
 
 ## Changelog ##
+
+### 2.4.0 - 2020-12-16 ###
+
+* Torna o plugin Brazilian Market on WooCommerce obrigatório
 
 ### 2.3.0 - 2020-11-05 ###
 

--- a/includes/admin/views/html-notice-missing-brazilian-market.php
+++ b/includes/admin/views/html-notice-missing-brazilian-market.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Notice: Missing Brazilian Market.
+ *
+ * @package WooCommerce_Pagarme/Admin/Notices
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$is_installed = false;
+
+if ( function_exists( 'get_plugins' ) ) {
+	$all_plugins  = get_plugins();
+	$is_installed = ! empty( $all_plugins['woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php'] );
+}
+
+?>
+
+<div class="error">
+	<p><strong><?php esc_html_e( 'WooCommerce Pagar.me', 'woocommerce-pagarme' ); ?></strong> <?php esc_html_e( 'depends on the last version of Brazilian Market to work!', 'woocommerce-pagarme' ); ?></p>
+
+	<?php if ( $is_installed && current_user_can( 'install_plugins' ) ) : ?>
+		<p><a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php&plugin_status=active' ), 'activate-plugin_woocommerce-extra-checkout-fields-for-brazil/woocommerce-extra-checkout-fields-for-brazil.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Active Brazilian Market', 'woocommerce-pagarme' ); ?></a></p>
+	<?php else : ?>
+		<?php if ( current_user_can( 'install_plugins' ) ) : ?>
+			<p><a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woocommerce-extra-checkout-fields-for-brazil' ), 'install-plugin_woocommerce-extra-checkout-fields-for-brazil' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Install Brazilian Market', 'woocommerce-pagarme' ); ?></a></p>
+		<?php else : ?>
+			<p><a href="https://wordpress.org/plugins/woocommerce-extra-checkout-fields-for-brazil/" class="button button-primary"><?php esc_html_e( 'Install Brazilian Market', 'woocommerce-pagarme' ); ?></a></p>
+		<?php endif; ?>
+	<?php endif; ?>
+</div>

--- a/languages/woocommerce-pagarme.pot
+++ b/languages/woocommerce-pagarme.pot
@@ -2,10 +2,10 @@
 # This file is distributed under the GPLv2 or later.
 msgid ""
 msgstr ""
-"Project-Id-Version: Pagar.me for WooCommerce 2.3.0\n"
+"Project-Id-Version: Pagar.me for WooCommerce 2.4.0\n"
 "Report-Msgid-Bugs-To: "
 "https://wordpress.org/support/plugin/woocommerce-pagarme\n"
-"POT-Creation-Date: 2020-11-05 12:15:09+00:00\n"
+"POT-Creation-Date: 2020-12-16 15:51:50+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -22,8 +22,22 @@ msgstr ""
 msgid "Currency %s is not supported. Works only with Brazilian Real."
 msgstr ""
 
+#: includes/admin/views/html-notice-missing-brazilian-market.php:22
 #: includes/admin/views/html-notice-missing-woocommerce.php:22
 msgid "WooCommerce Pagar.me"
+msgstr ""
+
+#: includes/admin/views/html-notice-missing-brazilian-market.php:22
+msgid "depends on the last version of Brazilian Market to work!"
+msgstr ""
+
+#: includes/admin/views/html-notice-missing-brazilian-market.php:25
+msgid "Active Brazilian Market"
+msgstr ""
+
+#: includes/admin/views/html-notice-missing-brazilian-market.php:28
+#: includes/admin/views/html-notice-missing-brazilian-market.php:30
+msgid "Install Brazilian Market"
 msgstr ""
 
 #: includes/admin/views/html-notice-missing-woocommerce.php:22
@@ -485,11 +499,11 @@ msgstr ""
 msgid "%1$dx of %2$s %3$s"
 msgstr ""
 
-#: woocommerce-pagarme.php:132
+#: woocommerce-pagarme.php:139
 msgid "Bank Slip Settings"
 msgstr ""
 
-#: woocommerce-pagarme.php:134
+#: woocommerce-pagarme.php:141
 msgid "Credit Card Settings"
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: pagarme, claudiosanches, murilohns
 Tags: woocommerce, pagarme, payment
 Requires at least: 4.0
-Tested up to: 5.5
-Stable tag: 2.3.0
+Tested up to: 5.6
+Stable tag: 2.4.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -116,6 +116,10 @@ Entre em contato [clicando aqui](http://wordpress.org/support/plugin/woocommerce
 4. Configurações para cartão de crédito.
 
 == Changelog ==
+
+### 2.4.0 - 2020-12-16 ###
+
+* Torna o plugin Brazilian Market on WooCommerce obrigatório
 
 = 2.3.0 - 2020-11-05 =
 

--- a/tests/e2e/boleto.spec.js
+++ b/tests/e2e/boleto.spec.js
@@ -17,8 +17,7 @@ context('Boleto', () => {
 
     it('should countains boleto url', () => {
       cy.contains('Pagar boleto bancário')
-        .and('have.attr', 'href' )
-        .should('match', new RegExp(/https:\/\/api.pagar.me\/1\/boletos\/test_/g))
+        .and('have.attr', 'href', 'https://pagar.me') 
     })
   })
 })

--- a/tests/e2e/required-plugins.spec.js
+++ b/tests/e2e/required-plugins.spec.js
@@ -1,0 +1,42 @@
+context('WordPress Required Plugins', () => {
+  describe('when go to the wordpress plugins page', () => {
+    describe('and deactivate the brazilian market plugin', () => {
+      before(() => {
+        cy.goToPluginsPage()
+        cy.deactivateBrazilianMarketPlugin()
+      })
+  
+      it('should contains error message', () => {
+        cy.get('.error a.button')
+          .contains('Brazilian Market')
+          .should('have.attr', 'href')
+          .and('match', /plugins.php\?action\=activate\&plugin\=woocommerce-extra-checkout-fields-for-brazil/)
+      })
+
+      after(() => {
+        cy.goToPluginsPage()
+        cy.activateBrazilianMarketPlugin()
+      })
+    })
+
+    describe('and deactivate the woocommerce plugin', () => {
+      before(() => {
+        cy.goToPluginsPage()
+        cy.deactivateWoocommercePlugin()
+      })
+  
+      it('should contains error message', () => {
+        cy.get('.error a.button')
+          .contains('WooCommerce')
+          .should('have.attr', 'href')
+          .and('match', /plugins.php\?action\=activate\&plugin\=woocommerce/)
+      })
+
+      after(() => {
+        cy.goToPluginsPage()
+        cy.activateWoocommercePlugin()
+      })
+    })
+  })
+})
+  

--- a/tests/e2e/support/commands.js
+++ b/tests/e2e/support/commands.js
@@ -327,3 +327,39 @@ Cypress.Commands.add('refundOrder', (id, amount = 0) => {
 
   cy.wait(7000)
 })
+
+Cypress.Commands.add('goToPluginsPage', () => {
+  cy.log('Going to plugins page...')
+
+  cy.visit('/wp-admin/plugins.php')
+
+  cy.log('In plugins page.')
+})
+
+Cypress.Commands.add('deactivateBrazilianMarketPlugin', () => {
+  cy.log('Deactivating the Brazilian Market plugin...')
+
+  cy.get('#deactivate-woocommerce-extra-checkout-fields-for-brazil')
+  .click()
+})
+
+Cypress.Commands.add('activateBrazilianMarketPlugin', () => {
+  cy.log('Activating the Brazilian Market plugin...')
+
+  cy.get('#activate-woocommerce-extra-checkout-fields-for-brazil')
+  .click()
+})
+
+Cypress.Commands.add('deactivateWoocommercePlugin', () => {
+  cy.log('Deactivating the WooCommerce plugin...')
+
+  cy.get('#deactivate-woocommerce')
+  .click()
+})
+
+Cypress.Commands.add('activateWoocommercePlugin', () => {
+  cy.log('Activating the WooCommerce plugin...')
+
+  cy.get('#activate-woocommerce')
+  .click()
+})

--- a/woocommerce-pagarme.php
+++ b/woocommerce-pagarme.php
@@ -5,7 +5,7 @@
  * Description: Gateway de pagamento Pagar.me para WooCommerce.
  * Author: Pagar.me, Claudio Sanches
  * Author URI: https://pagar.me/
- * Version: 2.3.0
+ * Version: 2.4.0
  * License: GPLv2 or later
  * Text Domain: woocommerce-pagarme
  * Domain Path: /languages/
@@ -29,7 +29,7 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '2.3.0';
+		const VERSION = '2.4.0';
 
 		/**
 		 * Instance of this class.

--- a/woocommerce-pagarme.php
+++ b/woocommerce-pagarme.php
@@ -45,20 +45,27 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 			// Load plugin text domain.
 			add_action( 'init', array( $this, 'load_plugin_textdomain' ) );
 
-			// Checks if WooCommerce is installed.
-			if ( class_exists( 'WC_Payment_Gateway' ) ) {
+			// Checks if WooCommerce and Brazilian Market plugins are installed.
+			$woocommerce_is_installed = class_exists( 'WC_Payment_Gateway' );
+			$brazilian_market_is_installed = class_exists( 'Extra_Checkout_Fields_For_Brazil' );
+
+			if ( $woocommerce_is_installed && $brazilian_market_is_installed ) {
 				$this->upgrade();
 				$this->includes();
 
 				add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
 				add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
-			} else {
-				add_action( 'admin_notices', array( $this, 'woocommerce_missing_notice' ) );
-			}
 
-			// Custom settings for the "Brazilian Market on WooCommerce" plugin billing fields.
-			if ( class_exists( 'Extra_Checkout_Fields_For_Brazil' ) ) {
+				// Custom settings for Brazilian Market plugin billing fields.
 				add_action( 'wcbcf_billing_fields', array( $this, 'wcbcf_billing_fields_custom_settings' ) );
+			} else {
+				if ( ! $woocommerce_is_installed ) {
+					add_action( 'admin_notices', array( $this, 'woocommerce_missing_notice' ) );
+				}
+
+				if ( ! $brazilian_market_is_installed ) {
+					add_action( 'admin_notices', array( $this, 'brazilian_market_missing_notice' ) );
+				}
 			}
 		}
 
@@ -141,6 +148,13 @@ if ( ! class_exists( 'WC_Pagarme' ) ) :
 		 */
 		public function woocommerce_missing_notice() {
 			include dirname( __FILE__ ) . '/includes/admin/views/html-notice-missing-woocommerce.php';
+		}
+
+		/**
+		 * Brazilian Market fallback notice.
+		 */
+		public function brazilian_market_missing_notice() {
+			include dirname( __FILE__ ) . '/includes/admin/views/html-notice-missing-brazilian-market.php';
 		}
 
 		/**


### PR DESCRIPTION
Esse PR tem o intuito de tornar o plugin _Brazilian Market on WooCommerce_ obrigatório, reduzindo assim problemas e dúvidas de clientes Pagar.me no momento da instalação do plugin.

Obs.: Nesse PR também ajustei a url do teste de boleto, revertendo a alteração [desse commit](https://github.com/claudiosanches/woocommerce-pagarme/commit/4c8826704365301d981f7a054d8151d8ad5befd9), devido ao "revert" que também rolou aqui na Pagar.me.