### PR TITLE
Throw an error if parcel field is equal 0

### DIFF
--- a/assets/js/credit-card.js
+++ b/assets/js/credit-card.js
@@ -30,8 +30,14 @@
 			creditCard.cardNumber          = $( '#pagarme-card-number', form ).val().replace( /[^\d]/g, '' );
 			creditCard.cardCVV             = $( '#pagarme-card-cvc', form ).val();
 
-			// Get the errors.
-			errors = creditCard.fieldErrors();
+		    creditCard.parcels = $("#pagarme-installments", form).val();
+
+		    // Get the errors.
+		    errors = creditCard.fieldErrors();
+
+		    if (creditCard.parcels === "0") {
+			  errors.card_parcel = "Parcela Inválida";
+		    }
 
 			// Display the errors in credit card form.
 			if ( ! $.isEmptyObject( errors ) ) {


### PR DESCRIPTION
A more intelligent approach should add this validation on fieldErrors function. This was a problem that some clients were having, so these lines check if the option chosen is valid. The field gets empty if any update happens on the checkout, for example, if the shipping method was updated when the credit card information was already informed.